### PR TITLE
Add TT2 syntax highlighting support

### DIFF
--- a/src/js/vendor/highlight-tt2.js
+++ b/src/js/vendor/highlight-tt2.js
@@ -1,0 +1,85 @@
+const hljs = require('highlight.js/lib/highlight');
+
+function tt2PseudoPerl() {
+    return {
+        name: 'TT2 Pseudo-Perl',
+        contains: [
+            hljs.HASH_COMMENT_MODE,
+            hljs.QUOTE_STRING_MODE,
+            hljs.APOS_STRING_MODE,
+            hljs.C_NUMBER_MODE,
+            {
+                className: 'function',
+                begin: /(\$?[a-zA-Z_]\w*)\.(\w+)\s*\(/,
+                returnBegin: true,
+                contains: [
+                    {
+                        className: 'variable',
+                        begin: /(\$?[a-zA-Z_]\w*)/,
+                    },
+                    {
+                        className: 'function',
+                        begin: /\.(\w+)/,
+                        excludeBegin: true,
+                    },
+                    {
+                        begin: /\(/,
+                        end: /\)/,
+                        contains: [
+                            hljs.QUOTE_STRING_MODE,
+                            hljs.APOS_STRING_MODE,
+                            hljs.C_NUMBER_MODE,
+                            hljs.HASH_COMMENT_MODE
+                        ],
+                    },
+                ],
+            },
+            {
+                className: 'variable',
+                begin: /\$[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*/,
+            },
+            {
+                className: 'variable',
+                begin: /(\$?[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)/,
+                keywords: 'IF ELSE ELSIF UNLESS SWITCH CASE FOR FOREACH WHILE NEXT LAST RETURN STOP TRY THROW CATCH END FILTER MACRO SET DEFAULT INSERT INCLUDE PROCESS WRAPPER BLOCK CALL USE DEBUG TAGS',
+            }
+        ]
+    };
+}
+
+function tt2() {
+    return {
+        name: 'Template Toolkit (HTML + PseudoPerl)',
+        subLanguage: 'xml',
+        contains: [
+            {
+                begin: '\\[%-?',
+                end: '-?%\\]',
+                subLanguage: 'tt2-pseudoperl',
+                excludeBegin: true,
+                excludeEnd: true
+            },
+            {
+                begin: /<script\b[^>]*>/, 
+                end: /<\/script>/,
+                subLanguage: 'javascript',
+                excludeBegin: true,
+                excludeEnd: true,
+                contains: [
+                    {
+                        begin: '\\[%-?',
+                        end: '-?%\\]',
+                        subLanguage: 'tt2-pseudoperl',
+                        excludeBegin: true,
+                        excludeEnd: true
+                    }
+                ]
+            }
+        ]
+    };
+}
+
+module.exports = {
+    tt2PseudoPerl,
+    tt2
+};

--- a/src/js/vendor/highlight.bundle.js
+++ b/src/js/vendor/highlight.bundle.js
@@ -2,6 +2,7 @@
   'use strict'
 
   var hljs = require('highlight.js/lib/highlight')
+  var { tt2PseudoPerl, tt2 } = require('./highlight-tt2');
   hljs.registerLanguage('asciidoc', require('highlight.js/lib/languages/asciidoc'))
   hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'))
   hljs.registerLanguage('clojure', require('highlight.js/lib/languages/clojure'))
@@ -36,109 +37,8 @@
   hljs.registerLanguage('swift', require('highlight.js/lib/languages/swift'))
   hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
   hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
-  hljs.registerLanguage('tt2-pseudoperl', function (hljs) {
-    return {
-      name: 'TT2 Pseudo-Perl',
-
-      contains: [
-        // # or ## line comments
-        hljs.HASH_COMMENT_MODE,
-        // Single and double quoted strings
-        hljs.QUOTE_STRING_MODE,
-        hljs.APOS_STRING_MODE,
-        // Numbers
-        hljs.C_NUMBER_MODE,
-
-        /**
-         * Function calls with optional dot-chaining:
-         *  helpers.get_org_setting(...)   or   foo(...)
-         * We match up to '(' and then highlight the parentheses block separately.
-         */
-        {
-          className: 'function',
-          // e.g. helpers.get_org_setting( or user.foo(
-          // \s* allows optional whitespace before '('
-          begin: /(\$?[a-zA-Z_]\w*)\.(\w+)\s*\(/,
-          returnBegin: true,
-          contains: [
-            {
-              // Highlight the variable part (up to '.') as e.g. "variable"
-              className: 'variable',
-              begin: /(\$?[a-zA-Z_]\w*)/,
-            },
-            {
-              // Highlight the function name part (after '.') as e.g. "title.function"
-              className: 'function',
-              begin: /\.(\w+)/,
-              excludeBegin: true,
-            },
-            {
-              // Now match everything inside the parentheses
-              begin: /\(/,
-              end: /\)/,
-              contains: [
-                hljs.QUOTE_STRING_MODE,
-                hljs.APOS_STRING_MODE,
-                hljs.C_NUMBER_MODE,
-                hljs.HASH_COMMENT_MODE,
-                // You could also nest the variable rule here if needed
-              ],
-            },
-          ],
-        },
-
-        /**
-         * Variables: $foo, $foo.bar, etc.
-         * We first match those with a leading '$', so it won't conflict with keywords like IF.
-         */
-        {
-          className: 'variable',
-          // e.g. $foo, $foo.bar, $helpers.bar.baz
-          begin: /\$[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*/,
-        },
-
-        /**
-         * Bare identifiers (without a '$') to highlight as "variables" IF
-         * they're not recognized as keywords or function calls. Example: helpers, user.name
-         * If we place "keywords" at the top level, highlight.js will
-         * color IF/ELSE as keywords, so we won't overshadow them as variables.
-         */
-        {
-          className: 'variable',
-          // e.g. $foo, or just foo, or user.email
-          begin: /(\$?[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)/,
-          keywords: 'IF ELSE ELSIF UNLESS SWITCH CASE FOR FOREACH WHILE NEXT LAST RETURN STOP TRY THROW CATCH END FILTER MACRO SET DEFAULT INSERT INCLUDE PROCESS WRAPPER BLOCK CALL USE DEBUG TAGS',
-        },
-      ],
-    }
-  })
-
-  // Template Toolkit (HTML + PseudoPerl)
-  hljs.registerLanguage('tt2', function () {
-    return {
-      name: 'Template Toolkit (HTML + PseudoPerl)',
-      // Outside TT2 blocks → highlight as HTML/XML
-      subLanguage: 'xml',
-
-      contains: [
-        {
-          // This rule matches:
-          //   [%   ...   %]
-          //   [%-  ...  -%]
-          //   (dash optional in start/end)
-          begin: '\\[%-?',
-          end: '-?%\\]',
-          // Instead of "perl", use our custom "tt2-pseudoperl"
-          subLanguage: 'tt2-pseudoperl',
-
-          // Exclude the [% ... %] delimiters from the child grammar,
-          // so the bracket symbols themselves stay styled as HTML.
-          excludeBegin: true,
-          excludeEnd: true,
-        },
-      ],
-    }
-  })
+  hljs.registerLanguage('tt2-pseudoperl', tt2PseudoPerl);
+  hljs.registerLanguage('tt2', tt2);
 
   ;[].slice.call(document.querySelectorAll('pre code.hljs')).forEach(function (node) {
     hljs.highlightBlock(node)


### PR DESCRIPTION
- Introduce a new file `highlight-tt2.js` containing definitions for two languages: `TT2 Pseudo-Perl` and `Template Toolkit (HTML + PseudoPerl)`.
- In `highlight.bundle.js`, remove the inline definition of `tt2-pseudoperl` and `tt2` languages and instead import them from `highlight-tt2.js`.
- Register these languages with Highlight.js, enabling syntax highlighting for TT2 templates incorporating both TT2 statements and embedded JavaScript.

Release-Note: Add syntax highlighting support for TT2 templates featuring Pseudo-Perl and HTML.